### PR TITLE
ci: roll out shared github-actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,71 +11,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quality:
-    name: Quality (Elixir 1.19 / OTP 28)
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Elixir
-        uses: erlef/setup-beam@v1
-        with:
-          otp-version: "28"
-          elixir-version: "1.19"
-
-      - name: Cache deps and build
-        uses: actions/cache@v4
-        with:
-          path: |
-            deps
-            _build
-            priv/plts
-          key: ${{ runner.os }}-mix-quality-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-quality-
-
-      - name: Install dependencies
-        run: mix deps.get
-
-      - name: Run quality checks
-        run: mix quality
+  lint:
+    name: Lint
+    uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@main
+    with:
+      otp_version: "28"
+      elixir_version: "1.19"
+      validate_hex_package: false
 
   test:
-    name: Test (Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        elixir: ["1.18", "1.19"]
-        otp: ["27", "28"]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Elixir
-        uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{ matrix.otp }}
-          elixir-version: ${{ matrix.elixir }}
-
-      - name: Cache deps and build
-        uses: actions/cache@v4
-        with:
-          path: |
-            deps
-            _build
-          key: ${{ runner.os }}-mix-test-${{ matrix.elixir }}-${{ matrix.otp }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-test-${{ matrix.elixir }}-${{ matrix.otp }}-
-
-      - name: Install dependencies
-        run: mix deps.get
-
-      - name: Run tests
-        run: mix test
+    name: Test
+    uses: agentjido/github-actions/.github/workflows/elixir-test.yml@main
+    with:
+      otp_versions: '["27", "28"]'
+      elixir_versions: '["1.18", "1.19"]'
+      test_command: mix test
 
   coverage:
     name: Coverage
@@ -83,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Elixir
         uses: erlef/setup-beam@v1
@@ -92,7 +42,7 @@ jobs:
           elixir-version: "1.19"
 
       - name: Cache deps and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     name: Release
     uses: agentjido/github-actions/.github/workflows/elixir-release.yml@main
     with:
+      otp_version: "28"
+      elixir_version: "1.19"
       dry_run: ${{ inputs.dry_run }}
       hex_dry_run: ${{ inputs.hex_dry_run }}
       skip_tests: ${{ inputs.skip_tests }}

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,33 @@
 import Config
 
+if config_env() == :dev do
+  config :git_hooks,
+    auto_install: true,
+    verbose: true,
+    hooks: [
+      commit_msg: [
+        tasks: [
+          {:cmd, "mix git_ops.check_message", include_hook_args: true}
+        ]
+      ]
+    ]
+
+  config :git_ops,
+    mix_project: JidoCluster.MixProject,
+    changelog_file: "CHANGELOG.md",
+    repository_url: "https://github.com/agentjido/jido_cluster",
+    manage_mix_version?: true,
+    version_tag_prefix: "v",
+    types: [
+      feat: [header: "Features"],
+      fix: [header: "Bug Fixes"],
+      perf: [header: "Performance"],
+      refactor: [header: "Refactoring"],
+      docs: [hidden?: true],
+      test: [hidden?: true],
+      chore: [hidden?: true],
+      ci: [hidden?: true]
+    ]
+end
+
 import_config "#{config_env()}.exs"


### PR DESCRIPTION
## Summary
- move the repo onto the shared `agentjido/github-actions` lint and test workflows
- move release automation onto the shared git_ops-based release workflow
- add the minimal `git_ops` configuration needed for the shared release flow where this repo did not already have it

## Notes
- repo-specific extra jobs were only kept where they are part of the current CI contract
- this rollout intentionally avoids the known edge-case repos (`llm_db`, `jido_run`, browser/shell special cases, and the no-workflow repos)
