### PR TITLE
fix: support Elixir 1.20 strict compile

### DIFF
--- a/lib/jido_cluster/key_runtime.ex
+++ b/lib/jido_cluster/key_runtime.ex
@@ -918,8 +918,6 @@ defmodule JidoCluster.KeyRuntime do
     end
   end
 
-  defp maybe_push_primary_state(state, _peer, _desired_primary, _desired_standby), do: state
-
   defp promote_self(state) do
     state
     |> clear_promotion_timer()

--- a/lib/jido_cluster/storage/bedrock.ex
+++ b/lib/jido_cluster/storage/bedrock.ex
@@ -219,15 +219,15 @@ defmodule JidoCluster.Storage.Bedrock do
 
   defp fetch_repo(opts) do
     case Keyword.get(opts, :repo) do
+      nil ->
+        {:error, :missing_repo}
+
       repo when is_atom(repo) ->
         if Code.ensure_loaded?(repo) do
           {:ok, repo}
         else
           {:error, {:repo_not_loaded, repo}}
         end
-
-      nil ->
-        {:error, :missing_repo}
 
       other ->
         {:error, {:invalid_repo, other}}

--- a/lib/jido_cluster/storage/postgres.ex
+++ b/lib/jido_cluster/storage/postgres.ex
@@ -322,15 +322,15 @@ defmodule JidoCluster.Storage.Postgres do
 
   defp fetch_repo(opts) do
     case Keyword.get(opts, :repo) do
+      nil ->
+        {:error, :missing_repo}
+
       repo when is_atom(repo) ->
         if Code.ensure_loaded?(repo) do
           {:ok, repo}
         else
           {:error, {:repo_not_loaded, repo}}
         end
-
-      nil ->
-        {:error, :missing_repo}
 
       other ->
         {:error, {:invalid_repo, other}}


### PR DESCRIPTION
## Summary
- Fix strict compiler warnings under Elixir 1.20 / OTP 29.
- Remove unused dependency lock entries where applicable.

## Verification
- mise exec erlang@29.0.1 elixir@1.20 -- mix compile --force --warnings-as-errors
- mise exec erlang@29.0.1 elixir@1.20 -- mix deps.unlock --check-unused
- mise exec erlang@29.0.1 elixir@1.20 -- mix format --check-formatted

Tests were not run; compile-only verification was requested.